### PR TITLE
Return state as function definition requires.

### DIFF
--- a/AD774X_Init_V1_5/AD774X_I2C_V1_5.ino
+++ b/AD774X_Init_V1_5/AD774X_I2C_V1_5.ino
@@ -49,6 +49,7 @@ uint8_t AD774X_Write_Single_Register(uint8_t RegAdres, uint8_t DataSingl) {
   Wire.write(RegAdres);
   Wire.write(DataSingl);
   I2C_State = Wire.endTransmission();
+  return I2C_State;
 }
 //---------------------------------------------------------------------
 // Writes to the registry a defined number of bytes that are stored in the RxBuff field


### PR DESCRIPTION
The read_single_register function claims to return an integer representing the status of the register read operation, but the function did not return a value. This caused any read operation to hang at this point waiting for a return. This is a simple single-line fix to that issue.